### PR TITLE
Add Fluent Bit retry configuration

### DIFF
--- a/docs/ingest-via-json-api-endpoint-3416f8f.md
+++ b/docs/ingest-via-json-api-endpoint-3416f8f.md
@@ -23,7 +23,8 @@ You can use arbitrary log shippers to send to the mTLS ingest JSON API endpoint.
     tls true
     Compress gzip
     URI /
-   Format json
+    Format json
+    Retry_Limit 3
 
 ```
 


### PR DESCRIPTION
By default Fluent Bit [uses](https://docs.fluentbit.io/manual/administration/scheduling-and-retries#configuring-retries) a Retry_Limit of 1.
Since senders want to ensure that telemetry data is ingested, even if the observability backend (here SAP Cloud Logging) is temporarily unavailable (e.g. due to network problems), we should recommend at least 3 retries.



