### PR TITLE
Add proper examples to the SAML configuration

### DIFF
--- a/docs/prerequisites-41d8559.md
+++ b/docs/prerequisites-41d8559.md
@@ -143,14 +143,14 @@ Parameterization
 </td>
 <td valign="top">
 
-Set IdP information `idp.metadata_url` and `idp.entity_id` from Obtain SAML 2.0 IdP Information step.
+Set IdP information `idp.metadata_url` (e.g.: `https://myaccount.accounts.ondemand.com/saml2/metadata`) and `idp.entity_id` (e.g. `https://myaccount.accounts.ondemand.com`) from Obtain SAML 2.0 IdP Information step.
 
 </td>
 </tr>
 <tr>
 <td valign="top">
 
-Set `sp.entity_id` from Create a SAML 2.0 application step.
+Set `sp.entity_id` from Create a SAML 2.0 application step (Do not confuse with `idp.entity_id`)
 
 </td>
 </tr>


### PR DESCRIPTION
The idp.entity_id field is easily confused with the sp.entity_id field when people follow the documentation. By including a basic example and explicitly mentioning that these two are not the same, this problem can be avoided.

