### PR TITLE
docs: document span_passthrough configuration for ingest_otlp

### DIFF
--- a/docs/configuration-parameters-1830bca.md
+++ b/docs/configuration-parameters-1830bca.md
@@ -526,6 +526,31 @@ Enables ingestion over the OpenTelemetry Protocol. Defaults to `false`. For more
 
 </td>
 </tr>
+<tr>
+<td valign="top">
+
+span\_passthrough
+
+</td>
+<td valign="top">
+
+No
+
+</td>
+<td valign="top">
+
+Boolean
+
+</td>
+<td valign="top">
+
+When set to `true`, spans are written to OpenSearch individually as they arrive, without assembling complete traces.
+
+> ### Note:  
+> When `span_passthrough` is enabled, the service map \(`otel-v1-apm-service-map` index\) is not populated and trace views in OpenSearch Dashboards may show incomplete traces. Use this only when you need raw span data and do not require service map or full trace assembly.
+
+</td>
+</tr>
 </table>
 
 
@@ -1011,6 +1036,10 @@ The following snippet shows a sample payload that could be used for a `standard`
 >     "enabled": true,
 >     "max_instances": 10,
 >     "min_instances": 3
+>   },
+>   "ingest_otlp": {
+>     "enabled": true,
+>     "span_passthrough": false
 >   },
 >   "retention_period": 14
 > }

--- a/docs/ingest-via-opentelemetry-api-endpoint-fdc78af.md
+++ b/docs/ingest-via-opentelemetry-api-endpoint-fdc78af.md
@@ -29,6 +29,20 @@ OpenTelemetry support in SAP Cloud Logging needs to be enabled with a service in
 
     After OpenTelemetry has been enabled, the endpoint is added to the service instance.
 
+    > ### Note:  
+    > By default, the trace pipeline assembles complete traces and populates the service map \(`otel-v1-apm-service-map` index\). If you only need raw span data and do not require service map or full trace assembly, you can enable span passthrough mode:
+    > 
+    > ```
+    > {
+    >     "ingest_otlp": {
+    >         "enabled": true,
+    >         "span_passthrough": true
+    >     }
+    > }
+    > ```
+    > 
+    > When `span_passthrough` is set to `true`, spans are written to OpenSearch individually as they arrive. The service map is not populated and trace views may show incomplete traces.
+
 2.  Retrieve Endpoint and Certificates.
 
     Once OpenTelemetry ingestion is enabled, all new service bindings and service keys contain the required endpoint and credentials for mutual TLS. SAP Cloud Logging only supports mTLS for the OTLP endpoint. The service key contains the following OTLP-related properties:


### PR DESCRIPTION
## Summary

  - Adds `span_passthrough` parameter row to the `ingest_otlp` configuration table in
  `configuration-parameters-1830bca.md`, including default value, prerequisite (`enabled: true`), and
  a note on the service map / trace assembly trade-off
  - Updates the sample JSON to include `span_passthrough`
  - Adds a note in `ingest-via-opentelemetry-api-endpoint-fdc78af.md` explaining when and how to use
  `span_passthrough`, with a sample config snippet and the limitation that the service map is not
  populated