### PR TITLE
Add note on API Access scope for OpenID client secret

### DIFF
--- a/docs/integrate-sap-cloud-identity-services-identity-authentication-openid-connect-with-sap-clo-b2fffa4.md
+++ b/docs/integrate-sap-cloud-identity-services-identity-authentication-openid-connect-with-sap-clo-b2fffa4.md
@@ -33,6 +33,8 @@ Obtain OpenID Connect Identity Provider \(IdP\) Information based on the [Identi
 ## Create an OpenID Connect application
 
 Create an OpenID Connect application in your Identity Authentication account based on the [Identity Authentication guide](https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/create-openid-connect-application). Create OpenID client secrets based on the [Configuration Guide](https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/auth-configure-secrets-for-api-authentication)
+    > ### Note:  
+    > Make sure to provide API Access scope "OpenID" to the OpenID client secret created on the Identity Authentication application.
 
 
 


### PR DESCRIPTION
Added a note about providing API Access scope 'OpenID' for the OpenID client secret in the Identity Authentication application.
